### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Technically, yes. However, we strongly advise against it at the moment. Backpack
 <details>
   <summary>What syntactic features are transpiled? How do I change them?</summary>
   
-We track V8. Since V8 has wide support for ES6 and async and await, we transpile those. Since V8 doesn’t support class decorators, we don’t transpile those.
+We track V8. Since V8 has wide support for ES6, we don't transpile it. Since V8 doesn’t support and async/await and class decorators yet, we transpile those.
   
   See [this](https://github.com/palmerhq/backpack/blob/master/packages/backpack-core/config/webpack.config.js#L83) and [this](https://github.com/palmerhq/backpack#customizing-webpack)
 </details>

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Technically, yes. However, we strongly advise against it at the moment. Backpack
 <details>
   <summary>What syntactic features are transpiled? How do I change them?</summary>
   
-We track V8. Since V8 has wide support for ES6, we don't transpile it. Since V8 doesn’t support and async/await and class decorators yet, we transpile those.
+We track V8. Since V8 has wide support for ES6, we don't transpile it. Since V8 doesn’t support and async/await and class properties yet, we transpile those.
   
   See [this](https://github.com/palmerhq/backpack/blob/master/packages/backpack-core/config/webpack.config.js#L83) and [this](https://github.com/palmerhq/backpack#customizing-webpack)
 </details>


### PR DESCRIPTION
V8 supports [99% of ES2015/16](http://node.green/) = `backpack` [does not transpile it](https://github.com/palmerhq/backpack/blob/master/packages/backpack-core/babel.js#L7).
V8 does not support [async/await without a flag](http://node.green/#async-functions) and class properties = `backpack` [transpiles](https://github.com/palmerhq/backpack/blob/master/packages/backpack-core/babel.js#L14) [them](https://github.com/palmerhq/backpack/blob/master/packages/backpack-core/babel.js#L17).