### PR TITLE
Check path prefix with `.indexOf() === 0`

### DIFF
--- a/packages/backpack-core/config/webpack.config.js
+++ b/packages/backpack-core/config/webpack.config.js
@@ -116,8 +116,8 @@ module.exports = (options) => {
         raw: true,
         entryOnly: false,
         banner: `require('${
-            // Is source-map-support installed as project dependency, or linked?
-            require.resolve('source-map-support').match(process.cwd())
+          // Is source-map-support installed as project dependency, or linked?
+          ( require.resolve('source-map-support').indexOf(process.cwd()) === 0 )
             // If it's resolvable from the project root, it's a project dependency.
             ? 'source-map-support/register'
             // It's not under the project, it's linked via lerna.


### PR DESCRIPTION
`match` finds in any place of the string, but `indexOf() === 0` ensures it's at the start (the latter is the underlying intent here).

Refs https://github.com/palmerhq/backpack/pull/44/files#r101360579
Refs https://github.com/palmerhq/backpack/issues/42