### PR TITLE
Allow multiplie targets

### DIFF
--- a/packages/backpack-core/bin/build
+++ b/packages/backpack-core/bin/build
@@ -23,12 +23,17 @@ const fullConfig = userConfig.webpack
       : defaultConfig(options)
 
 const serverConfig = Array.isArray(fullConfig)
-      ? fullConfig.filter(({target} = {}) => { target === 'node' })[0]
+      ? fullConfig.filter(({target} = {}) => target === 'node')[0]
       : serverConfig;
 
 process.on('SIGINT', process.exit)
 
 const serverCompiler = webpack(fullConfig)
+
+const serverCompiler = compilers.compilers
+      ? compilers.compilers.filter(({options: {target}}) => target === 'node')[0]
+      : compilers
+
 const compileServer = () => serverCompiler.run(() => undefined)
 
 compileServer()

--- a/packages/backpack-core/bin/build
+++ b/packages/backpack-core/bin/build
@@ -18,13 +18,17 @@ if (fs.existsSync(configPath)) {
   userConfig = userConfigModule.default || userConfigModule
 }
 
-const serverConfig = userConfig.webpack
+const fullConfig = userConfig.webpack
       ? userConfig.webpack(defaultConfig(options), options)
       : defaultConfig(options)
 
+const serverConfig = Array.isArray(fullConfig)
+      ? fullConfig.filter(({target} = {}) => { target === 'node' })[0]
+      : serverConfig;
+
 process.on('SIGINT', process.exit)
 
-const serverCompiler = webpack(serverConfig)
+const serverCompiler = webpack(fullConfig)
 const compileServer = () => serverCompiler.run(() => undefined)
 
 compileServer()

--- a/packages/backpack-core/bin/dev
+++ b/packages/backpack-core/bin/dev
@@ -19,13 +19,17 @@ if (fs.existsSync(configPath)) {
   userConfig = userConfigModule.default || userConfigModule
 }
 
-const serverConfig = userConfig.webpack
+const fullConfig = userConfig.webpack
       ? userConfig.webpack(defaultConfig(options), options)
       : defaultConfig(options)
 
+const serverConfig = Array.isArray(fullConfig)
+      ? fullConfig.filter(({target} = {}) => { target === 'node' })[0]
+      : serverConfig;
+
 process.on('SIGINT', process.exit)
 
-const serverCompiler = webpack(serverConfig)
+const serverCompiler = webpack(fullConfig)
 
 const startServer = () => {
   const serverPaths = Object

--- a/packages/backpack-core/bin/dev
+++ b/packages/backpack-core/bin/dev
@@ -23,13 +23,13 @@ const fullConfig = userConfig.webpack
       ? userConfig.webpack(defaultConfig(options), options)
       : defaultConfig(options)
 
-const serverConfig = Array.isArray(fullConfig)
-      ? fullConfig.filter(({target} = {}) => { target === 'node' })[0]
-      : serverConfig;
-
 process.on('SIGINT', process.exit)
 
-const serverCompiler = webpack(fullConfig)
+const compilers = webpack(fullConfig)
+
+const serverCompiler = compilers.compilers
+      ? compilers.compilers.filter(({options: {target}}) => target === 'node')[0]
+      : compilers
 
 const startServer = () => {
   const serverPaths = Object
@@ -43,4 +43,4 @@ const startServerOnce = once((err, stats) => {
   if (err) return
   startServer()
 })
-serverCompiler.watch({}, startServerOnce)
+compilers.watch({}, startServerOnce)


### PR DESCRIPTION
Webpack can't use multiplie targets in one config https://webpack.js.org/concepts/targets/#multiple-targets, i think this patch can resolve this problem.

Example configuration

```js

module.exports = {
    webpack(serverConfig, options) {
        const clientConfig = {
            target: 'web', // <=== can be omitted as default is 'web'
            entry: {
                client: ['src/client/index.js']
            },
            output: {
                path: 'build',
                filename: '[name].js',
                sourceMapFilename: '[name].map',
                publicPath: '/',
                libraryTarget: 'commonjs'
            }
        };

        return [serverConfig, clientConfig];
    }
};


```