### PR TITLE
Allow custom watchOptions for webpack.watch

### DIFF
--- a/packages/backpack-core/bin/dev
+++ b/packages/backpack-core/bin/dev
@@ -39,4 +39,4 @@ const startServerOnce = once((err, stats) => {
   if (err) return
   startServer()
 })
-serverCompiler.watch({}, startServerOnce)
+serverCompiler.watch(serverConfig.watchOptions || {}, startServerOnce)


### PR DESCRIPTION
This pr allow to pass custom watchOptions to webpack.
I am currently using backpack ( thanks btw :) ) in my project and I run into an issue with webpack and docker for mac (you can find the issue [here](https://github.com/webpack/webpack-dev-server/issues/143#issuecomment-219147351)).
To fix my issue I need to be able to setup webpack [watchOptions](https://webpack.js.org/configuration/watch/#watchoptions).

Here is a working example:
```javascript
// backpack.config.js
module.exports = {
  webpack: (config) => {
    config.watchOptions = { poll: true };
    return config;
  },
};
```