### PR TITLE
Use NoEmitOnErrorsPlugin instead of NoErrorsPlugin

### DIFF
--- a/packages/backpack-core/config/webpack.config.js
+++ b/packages/backpack-core/config/webpack.config.js
@@ -127,11 +127,9 @@ module.exports = (options) => {
       // The FriendlyErrorsWebpackPlugin (when combined with source-maps)
       // gives Backpack its human-readable error messages.
       new FriendlyErrorsWebpackPlugin(),
-      // This plugin is awkwardly named. Use to be called NoErrorsPlugin.
-      // It does not actually swallow errors. Instead, it just prevents
-      // Webpack from printing out compile time stats to the console.
-      // @todo new webpack.NoEmitOnErrorsPlugin()
-      new webpack.NoErrorsPlugin()
+      // The NoEmitOnErrorsPlugin plugin prevents Webpack
+      // from printing out compile time stats to the console.
+      new webpack.NoEmitOnErrorsPlugin()
     ]
   }
 }


### PR DESCRIPTION
While playing with a fresh Nuxt [express-template](https://github.com/nuxt-community/express-template) (which uses the awesome backpack) find an strange warning without any message and after some checks, it is simply with `NoErrorsPlugin` which is deprecated with the current version of webpack. It seems you have already marked this as a TODO. Is there any special problem with this change? If so i would be happy resolve that, else feel free closing this PR if already had a plan for that.
